### PR TITLE
Update the CMD to use the shell syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /usr/local/sauce-connect/sc-$SAUCE_VERSION-linux
 
 EXPOSE 8032
 
-CMD ["./bin/sc", "-P", "8000", "-u", "$SAUCE_USERNAME", "-k", "$SAUCE_ACCESS_KEY"]
+CMD ./bin/sc -P 8000 -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY


### PR DESCRIPTION
With the most recent version of Docker, the CMD syntax does not translate environment variables.  See the third NOTE on below CMD here:  http://docs.docker.com/reference/builder/#cmd
