### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ sc -P 8000 -u $SAUCE_USERNAME -k SAUCE_ACCESS_KEY
 Or just
 
 ```sh
-$ docker run -rm -it \
+$ docker run --rm -it \
              -p 0.0.0.0:8000:8000 \
              ustwo/docker-sauce-connect -P 8000 \
                                         -u $SAUCE_USERNAME \


### PR DESCRIPTION
replace -rm with --rm
-rm produces error: 
unknown shorthand flag: 'r' in -rm
See 'docker run --help'